### PR TITLE
Adds '.hypothesis' to python project dir list in lib.rs

### DIFF
--- a/rmrfrs-lib/src/lib.rs
+++ b/rmrfrs-lib/src/lib.rs
@@ -53,7 +53,8 @@ const PROJECT_UNREAL_DIRS: [&str; 5] = [
     "Intermediate",
 ];
 const PROJECT_JUPYTER_DIRS: [&str; 1] = [".ipynb_checkpoints"];
-const PROJECT_PYTHON_DIRS: [&str; 8] = [
+const PROJECT_PYTHON_DIRS: [&str; 9] = [
+    ".hypothesis",
     ".mypy_cache",
     ".nox",
     ".pytest_cache",


### PR DESCRIPTION
# Patch Notes

On the rationale that '.hypothesis' is similar to '.pytest_cache' in testing, if the user wants to reset one, it makes sense to want to reset both.

---

Hope this helps